### PR TITLE
Added maven-compiler-plugin to pom.xml - Fix #1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   


### PR DESCRIPTION
Present config breaks the mvn build with 'annotations not supported' ERROR.
Made the source and target to be 1.6
